### PR TITLE
Remove logger statements for ignored requests

### DIFF
--- a/Civi/CiviAuth0Jwt/CheckAuth0JwtCredential.php
+++ b/Civi/CiviAuth0Jwt/CheckAuth0JwtCredential.php
@@ -82,6 +82,7 @@ class CheckAuth0JwtCredential implements EventSubscriberInterface {
         // Not a valid AuthX JWT. Proceed to check any other token sources.
       }
       catch (\Exception $e) {
+        // Not a valid AuthX JWT. Proceed to check any other token sources.
       }
     }
   }

--- a/Civi/CiviAuth0Jwt/CheckAuth0JwtCredential.php
+++ b/Civi/CiviAuth0Jwt/CheckAuth0JwtCredential.php
@@ -80,10 +80,8 @@ class CheckAuth0JwtCredential implements EventSubscriberInterface {
       }
       catch (CryptoException $e) {
         // Not a valid AuthX JWT. Proceed to check any other token sources.
-        Logger::debug("IGNORED, decode failed (CryptoException): " . $e->getMessage());
       }
       catch (\Exception $e) {
-        Logger::debug("IGNORED, decode failed (Exception): " . $e->getMessage());
       }
     }
   }

--- a/info.xml
+++ b/info.xml
@@ -14,13 +14,13 @@
     <url desc="Support">https://github.com/australiangreens/civiauth0jwt</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2022-07-22</releaseDate>
-  <version>1.0.0</version>
-  <develStage>alpha</develStage>
+  <releaseDate>2024-06-07</releaseDate>
+  <version>1.0.1</version>
+  <develStage>stable</develStage>
   <compatibility>
     <ver>5.45</ver>
   </compatibility>
-  <comments>This is a new module that is still a WIP</comments>
+  <comments></comments>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>


### PR DESCRIPTION
This extension is logging an extraordinarily high number of "IGNORED, decode failed..." messages, which isn't terribly surprising when many of the requests hitting our API endpoints aren't using JWTs.

I'm removing the logger statements to reduce the clutter in the logs.

Otherwise the changes here involve promoting the extension to stable and incrementing the version number.