### PR TITLE
Run civix upgrade

### DIFF
--- a/civiauth0jwt.civix.php
+++ b/civiauth0jwt.civix.php
@@ -24,7 +24,7 @@ class CRM_CiviAuth0Jwt_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = []) {
+  public static function ts($text, $params = []): string {
     if (!array_key_exists('domain', $params)) {
       $params['domain'] = [self::LONG_NAME, NULL];
     }
@@ -41,7 +41,7 @@ class CRM_CiviAuth0Jwt_ExtensionUtil {
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
+  public static function url($file = NULL): string {
     if ($file === NULL) {
       return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }
@@ -84,27 +84,17 @@ use CRM_CiviAuth0Jwt_ExtensionUtil as E;
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _civiauth0jwt_civix_civicrm_config(&$config = NULL) {
+function _civiauth0jwt_civix_civicrm_config($config = NULL) {
   static $configured = FALSE;
   if ($configured) {
     return;
   }
   $configured = TRUE;
 
-  $template = CRM_Core_Smarty::singleton();
-
   $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
-
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -114,35 +104,7 @@ function _civiauth0jwt_civix_civicrm_config(&$config = NULL) {
  */
 function _civiauth0jwt_civix_civicrm_install() {
   _civiauth0jwt_civix_civicrm_config();
-  if ($upgrader = _civiauth0jwt_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function _civiauth0jwt_civix_civicrm_postInstall() {
-  _civiauth0jwt_civix_civicrm_config();
-  if ($upgrader = _civiauth0jwt_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function _civiauth0jwt_civix_civicrm_uninstall() {
-  _civiauth0jwt_civix_civicrm_config();
-  if ($upgrader = _civiauth0jwt_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -150,58 +112,9 @@ function _civiauth0jwt_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _civiauth0jwt_civix_civicrm_enable() {
+function _civiauth0jwt_civix_civicrm_enable(): void {
   _civiauth0jwt_civix_civicrm_config();
-  if ($upgrader = _civiauth0jwt_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- * @return mixed
- */
-function _civiauth0jwt_civix_civicrm_disable() {
-  _civiauth0jwt_civix_civicrm_config();
-  if ($upgrader = _civiauth0jwt_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed
- *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *   for 'enqueue', returns void
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function _civiauth0jwt_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _civiauth0jwt_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
-}
-
-/**
- * @return CRM_CiviAuth0Jwt_Upgrader
- */
-function _civiauth0jwt_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/CiviAuth0Jwt/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_CiviAuth0Jwt_Upgrader_Base::instance();
-  }
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -220,8 +133,8 @@ function _civiauth0jwt_civix_insert_navigation_menu(&$menu, $path, $item) {
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
       ], $item),
     ];
     return TRUE;
@@ -258,7 +171,7 @@ function _civiauth0jwt_civix_navigationMenu(&$nodes) {
  */
 function _civiauth0jwt_civix_fixNavigationMenu(&$nodes) {
   $maxNavID = 1;
-  array_walk_recursive($nodes, function ($item, $key) use (&$maxNavID) {
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
     if ($key === 'navID') {
       $maxNavID = max($maxNavID, $item);
     }
@@ -284,15 +197,4 @@ function _civiauth0jwt_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parent
       _civiauth0jwt_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
   }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function _civiauth0jwt_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
 }

--- a/civiauth0jwt.php
+++ b/civiauth0jwt.php
@@ -66,59 +66,12 @@ function civiauth0jwt_civicrm_install() {
 }
 
 /**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function civiauth0jwt_civicrm_postInstall() {
-  _civiauth0jwt_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function civiauth0jwt_civicrm_uninstall() {
-  _civiauth0jwt_civix_civicrm_uninstall();
-}
-
-/**
  * Implements hook_civicrm_enable().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function civiauth0jwt_civicrm_enable() {
   _civiauth0jwt_civix_civicrm_enable();
-}
-
-/**
- * Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- */
-function civiauth0jwt_civicrm_disable() {
-  _civiauth0jwt_civix_civicrm_disable();
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function civiauth0jwt_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _civiauth0jwt_civix_civicrm_upgrade($op, $queue);
-}
-
-/**
- * Implements hook_civicrm_entityTypes().
- *
- * Declare entity types provided by this module.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function civiauth0jwt_civicrm_entityTypes(&$entityTypes) {
-  _civiauth0jwt_civix_civicrm_entityTypes($entityTypes);
 }
 
 // --- Functions below this ship commented out. Uncomment as required. ---

--- a/info.xml
+++ b/info.xml
@@ -14,19 +14,20 @@
     <url desc="Support">https://github.com/australiangreens/civiauth0jwt</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-06-07</releaseDate>
-  <version>1.0.1</version>
+  <releaseDate>2025-07-31</releaseDate>
+  <version>1.1.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.45</ver>
   </compatibility>
-  <comments></comments>
+  <comments/>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
+    <psr0 prefix="CRM_" path="."/>
   </classloader>
   <civix>
     <namespace>CRM/CiviAuth0Jwt</namespace>
-    <format>22.05.2</format>
+    <format>25.01.1</format>
   </civix>
   <requires>
     <ext>authx</ext>
@@ -34,5 +35,6 @@
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
+    <mixin>smarty-v2@1.0.3</mixin>
   </mixins>
 </extension>

--- a/mixin/smarty-v2@1.0.3.mixin.php
+++ b/mixin/smarty-v2@1.0.3.mixin.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Auto-register "templates/" folder.
+ *
+ * @mixinName smarty-v2
+ * @mixinVersion 1.0.3
+ * @since 5.59
+ *
+ * @deprecated - it turns out that the mixin is not version specific so the 'smarty'
+ * mixin is preferred over smarty-v2 (they are the same but not having the version
+ * in the name is less misleading.)
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+  $dir = $mixInfo->getPath('templates');
+  if (!file_exists($dir)) {
+    return;
+  }
+
+  $register = function($newDirs) {
+    $smarty = CRM_Core_Smarty::singleton();
+    $v2 = isset($smarty->_version) && version_compare($smarty->_version, 3, '<');
+    $templateDirs = (array) ($v2 ? $smarty->template_dir : $smarty->getTemplateDir());
+    $templateDirs = array_merge($newDirs, $templateDirs);
+    $templateDirs = array_unique(array_map(function($v) {
+      $v = str_replace(DIRECTORY_SEPARATOR, '/', $v);
+      $v = rtrim($v, '/') . '/';
+      return $v;
+    }, $templateDirs));
+    if ($v2) {
+      $smarty->template_dir = $templateDirs;
+    }
+    else {
+      $smarty->setTemplateDir($templateDirs);
+    }
+  };
+
+  // Let's figure out what environment we're in -- so that we know the best way to call $register().
+
+  if (!empty($GLOBALS['_CIVIX_MIXIN_POLYFILL'])) {
+    // Polyfill Loader (v<=5.45): We're already in the middle of firing `hook_config`.
+    if ($mixInfo->isActive()) {
+      $register([$dir]);
+    }
+    return;
+  }
+
+  if (CRM_Extension_System::singleton()->getManager()->extensionIsBeingInstalledOrEnabled($mixInfo->longName)) {
+    // New Install, Standard Loader: The extension has just been enabled, and we're now setting it up.
+    // System has already booted. New templates may be needed for upcoming installation steps.
+    $register([$dir]);
+    return;
+  }
+
+  // Typical Pageview, Standard Loader: Defer the actual registration for a moment -- to ensure that Smarty is online.
+  // We need to bundle-up all dirs -- Smarty 3/4/5 is inefficient with processing repeated calls to `getTemplateDir()`+`setTemplateDir()`
+  if (!isset(Civi::$statics[__FILE__]['event'])) {
+    Civi::$statics[__FILE__]['event'] = 'civi.smarty-v2.addPaths.' . md5(__FILE__);
+    Civi::dispatcher()->addListener('hook_civicrm_config', function() use ($register) {
+      $dirs = [];
+      $event = \Civi\Core\Event\GenericHookEvent::create(['dirs' => &$dirs]);
+      Civi::dispatcher()->dispatch(Civi::$statics[__FILE__]['event'], $event);
+      $register($dirs);
+    });
+  }
+
+  Civi::dispatcher()->addListener(Civi::$statics[__FILE__]['event'], function($event) use ($mixInfo, $dir) {
+    if ($mixInfo->isActive()) {
+      array_unshift($event->dirs, $dir);
+    }
+  });
+
+};


### PR DESCRIPTION
This PR uses `civix upgrade` to update the extension to ensure compatibility with newer versions of Civi, Smarty, etc.
Tested in dev by deploying the code and using List Manager to query Civi via API using JWTs.